### PR TITLE
Add gpt partitions

### DIFF
--- a/test/data/manifests/fedora-ostree-image.mpp.yaml
+++ b/test/data/manifests/fedora-ostree-image.mpp.yaml
@@ -1,27 +1,34 @@
 version: '2'
 mpp-define-image:
   id: image
+  #10G
   size: '10737418240'
   table:
-    uuid: D209C89E-EA5E-4FBD-B161-B461CCE297E0
+    uuid: 00000000-0000-4000-a000-000000000001
     label: gpt
     partitions:
-      - id: bios-boot
-        size: 2048
+      - id: BIOS-BOOT
+        size: 1024
         type: 21686148-6449-6E6F-744E-656564454649
         bootable: true
         uuid: FAC7F1FB-3E8D-4137-A512-961DE09A5549
-      - id: efi
-        size: 204800
+      - id: EFI-SYSTEM
+        size: 130048
         type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         uuid: 68B2905B-DF3E-4FB3-80FA-49D1E773AA33
       - id: boot
-        size: 204800
+        size: 393216
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         uuid: 61B2905B-DF3E-4FB3-80FA-49D1E773AA32
-      - id: luks
+      - id: root
         type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
         uuid: CA7D7CCB-63ED-4C53-861C-1742536059CC
+sources:
+  org.osbuild.ostree:
+    items:
+      bf28f852e934b0c0b9eee232a58970e96adb3e691299b02376f8719530e03fb3:
+        remote:
+          url: https://kojipkgs.fedoraproject.org/ostree/repo/
 pipelines:
   - mpp-import-pipelines:
       path: fedora-vars.ipp.yaml
@@ -30,11 +37,6 @@ pipelines:
       id: build
     runner:
       mpp-format-string: org.osbuild.fedora{release}
-  - mpp-import-pipelines:
-      path: fedora-ostree-commit.mpp.yaml
-      ids:
-        - ostree-tree
-        - ostree-commit
   - name: image-tree
     build: name:build
     source-epoch: 1659397331
@@ -43,34 +45,35 @@ pipelines:
       - type: org.osbuild.ostree.pull
         options:
           repo: /ostree/repo
-          remote: osbuild
+          remote: fedora
         inputs:
           commits:
             type: org.osbuild.ostree
-            origin: org.osbuild.pipeline
+            origin: org.osbuild.source
             references:
-              name:ostree-commit:
-                ref: fedora/x86_64/osbuild
+              "bf28f852e934b0c0b9eee232a58970e96adb3e691299b02376f8719530e03fb3":
+                ref: fedora/x86_64/coreos/stable
       - type: org.osbuild.ostree.os-init
         options:
-          osname: fedora
+          osname: fedora-coreos
       - type: org.osbuild.ostree.config
         options:
           repo: /ostree/repo
           config:
             sysroot:
-              readonly: true
+              readonly: false
               bootloader: none
       - type: org.osbuild.mkdir
         options:
           paths:
             - path: /boot/efi
               mode: 448
+      - type: org.osbuild.ignition
       - type: org.osbuild.ostree.deploy
         options:
-          osname: fedora
-          ref: fedora/x86_64/osbuild
-          remote: osbuild
+          osname: fedora-coreos
+          ref: fedora/x86_64/coreos/stable
+          remote: fedora
           mounts:
             - /boot
             - /boot/efi
@@ -82,43 +85,13 @@ pipelines:
             - console=ttyS0
             - systemd.log_target=console
             - systemd.journald.forward_to_console=1
-            - luks.uuid=aedd1eef-f24e-425e-a9f3-bb5a1c996a95
-      - type: org.osbuild.ostree.fillvar
-        options:
-          deployment:
-            osname: fedora
-            ref: fedora/x86_64/osbuild
-      - type: org.osbuild.fstab
-        mounts:
-          - type: org.osbuild.ostree.deployment
-            name: ostree.deployment
-            options:
-              deployment:
-                osname: fedora
-                ref: fedora/x86_64/osbuild
-        options:
-          filesystems:
-            - label: boot
-              vfs_type: ext4
-              path: /boot
-              freq: 1
-              passno: 1
-            - label: root
-              vfs_type: xfs
-              path: /
-              freq: 1
-              passno: 1
-            - label: ESP
-              vfs_type: vfat
-              path: /boot/efi
-              options: umask=0077,shortname=winnt
-              freq: 0
-              passno: 2
+            - ignition.platform.id=qemu
+            - '$ignition_firstboot'
       - type: org.osbuild.ostree.selinux
         options:
           deployment:
-            osname: fedora
-            ref: fedora/x86_64/osbuild
+            osname: fedora-coreos
+            ref: fedora/x86_64/coreos/stable
       - type: org.osbuild.grub2
         options:
           rootfs:
@@ -130,7 +103,8 @@ pipelines:
             install: true
           legacy: i386-pc
           write_defaults: false
-          greenboot: true
+          greenboot: false
+          ignition: true
   - name: image
     build: name:build
     stages:
@@ -154,12 +128,12 @@ pipelines:
             options:
               filename: disk.img
               start:
-                mpp-format-int: '{image.layout[''efi''].start}'
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
               size:
-                mpp-format-int: '{image.layout[''efi''].size}'
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
               lock: true
         options:
-          label: ESP
+          label: EFI-SYSTEM
           volid: 7B7795E7
       - type: org.osbuild.mkfs.ext4
         devices:
@@ -173,69 +147,21 @@ pipelines:
                 mpp-format-int: '{image.layout[''boot''].size}'
               lock: true
         options:
-          uuid: 156f0420-627b-4151-ae6f-fda298097515
+          uuid: 96d15588-3596-4b3c-adca-a2ff7279ea63
           label: boot
-      - type: org.osbuild.luks2.format
-        devices:
-          device:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''luks''].start}'
-              size:
-                mpp-format-int: '{image.layout[''luks''].size}'
-              lock: true
-        options:
-          passphrase: osbuild
-          uuid: aedd1eef-f24e-425e-a9f3-bb5a1c996a95
-          label: luks
-          pbkdf:
-            method: argon2i
-            memory: 32
-            parallelism: 1
-            iterations: 4
-      - type: org.osbuild.lvm2.create
-        devices:
-          luks:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''luks''].start}'
-              size:
-                mpp-format-int: '{image.layout[''luks''].size}'
-          device:
-            type: org.osbuild.luks2
-            parent: luks
-            options:
-              passphrase: osbuild
-        options:
-          volumes:
-            - name: root
-              extents: 100%FREE
       - type: org.osbuild.mkfs.xfs
         devices:
-          luks:
+          device:
             type: org.osbuild.loopback
             options:
               filename: disk.img
               start:
-                mpp-format-int: '{image.layout[''luks''].start}'
+                mpp-format-int: '{image.layout[''root''].start}'
               size:
-                mpp-format-int: '{image.layout[''luks''].size}'
-          lvm:
-            type: org.osbuild.luks2
-            parent: luks
-            options:
-              passphrase: osbuild
-          device:
-            type: org.osbuild.lvm2.lv
-            parent: lvm
-            options:
-              volume: root
+                mpp-format-int: '{image.layout[''root''].size}'
+              lock: true
         options:
-          uuid: 76a22bf4-f153-4541-b6c7-0332c0dfaeac
+          uuid: 910678ff-f77e-4a7d-8d53-86f2ac47a823
           label: root
       - type: org.osbuild.copy
         inputs:
@@ -254,9 +180,9 @@ pipelines:
             options:
               filename: disk.img
               start:
-                mpp-format-int: '{image.layout[''efi''].start}'
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
               size:
-                mpp-format-int: '{image.layout[''efi''].size}'
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
           boot:
             type: org.osbuild.loopback
             options:
@@ -265,24 +191,14 @@ pipelines:
                 mpp-format-int: '{image.layout[''boot''].start}'
               size:
                 mpp-format-int: '{image.layout[''boot''].size}'
-          luks:
+          root:
             type: org.osbuild.loopback
             options:
               filename: disk.img
               start:
-                mpp-format-int: '{image.layout[''luks''].start}'
+                mpp-format-int: '{image.layout[''root''].start}'
               size:
-                mpp-format-int: '{image.layout[''luks''].size}'
-          lvm:
-            type: org.osbuild.luks2
-            parent: luks
-            options:
-              passphrase: osbuild
-          root:
-            type: org.osbuild.lvm2.lv
-            parent: lvm
-            options:
-              volume: root
+                mpp-format-int: '{image.layout[''root''].size}'
         mounts:
           - name: root
             type: org.osbuild.xfs
@@ -301,7 +217,7 @@ pipelines:
           platform: i386-pc
           filename: disk.img
           location:
-            mpp-format-int: '{image.layout[''bios-boot''].start}'
+            mpp-format-int: '{image.layout[''BIOS-BOOT''].start}'
           core:
             type: mkimage
             partlabel: gpt
@@ -313,25 +229,6 @@ pipelines:
             number:
               mpp-format-int: '{image.layout[''boot''].index}'
             path: /grub2
-      - type: org.osbuild.lvm2.metadata
-        devices:
-          luks:
-            type: org.osbuild.loopback
-            options:
-              filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''luks''].start}'
-              size:
-                mpp-format-int: '{image.layout[''luks''].size}'
-          device:
-            type: org.osbuild.luks2
-            parent: luks
-            options:
-              passphrase: osbuild
-        options:
-          vg_name: osbuild
-          creation_host: osbuild
-          description: Built with osbuild
   - name: qcow2
     build: name:build
     stages:

--- a/test/data/manifests/fedora-ostree-image.mpp.yaml
+++ b/test/data/manifests/fedora-ostree-image.mpp.yaml
@@ -113,14 +113,37 @@ pipelines:
           filename: disk.img
           size:
             mpp-format-string: '{image.size}'
-      - type: org.osbuild.sfdisk
+      - type: org.osbuild.parted
         devices:
           device:
             type: org.osbuild.loopback
             options:
               filename: disk.img
         options:
-          mpp-format-json: '{image.layout}'
+           label: gpt
+           partitions:
+             - start:
+                 mpp-format-int: '{image.layout[''BIOS-BOOT''].start}'
+               size:
+                 mpp-format-int: '{image.layout[''BIOS-BOOT''].size}'
+               bootable: true
+               type: bios_grub
+               name: BIOS-BOOT
+             - start:
+                 mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
+               size:
+                 mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
+               name: EFI-SYSTEM
+             - start:
+                 mpp-format-int: '{image.layout[''boot''].start}'
+               size:
+                 mpp-format-int: '{image.layout[''boot''].size}'
+               name: boot
+             - start:
+                 mpp-format-int: '{image.layout[''root''].start}'
+               size:
+                 mpp-format-int: '{image.layout[''root''].size}'
+               name: root
       - type: org.osbuild.mkfs.fat
         devices:
           device:


### PR DESCRIPTION
 - We need the '/dev/disk/by-partlabel/' partions created, specially the '/dev/disk/by-partlabel/BIOS-BOOT'

 - The following code creates the partitions in the same way we have in FCOS:

```
[core@cosa-devsh ~]$ ls -ls /dev/disk/by-partlabel/
total 0
0 lrwxrwxrwx. 1 root root 10 Aug 23 19:45 BIOS-BOOT -> ../../vda1
0 lrwxrwxrwx. 1 root root 10 Aug 23 19:45 EFI-SYSTEM -> ../../vda2
0 lrwxrwxrwx. 1 root root 10 Aug 23 19:45 boot -> ../../vda3
0 lrwxrwxrwx. 1 root root 10 Aug 23 19:45 root -> ../../vda4
```