### PR TITLE
stages/org.osbuild.mkfs.ext4: add ext4 options

### DIFF
--- a/stages/org.osbuild.mkfs.ext4
+++ b/stages/org.osbuild.mkfs.ext4
@@ -38,6 +38,14 @@ SCHEMA_2 = r"""
       "type": "string",
       "maxLength": 16
     },
+    "metadata_csum_seed": {
+      "description": "Enable metadata_csum_seed support",
+      "type": "boolean"
+    },
+    "orphan_file": {
+      "description": "Enable orphan_file support",
+      "type": "boolean"
+    },
     "verity": {
       "description": "Enable fs-verity support",
       "type": "boolean"
@@ -52,11 +60,25 @@ def main(devices, options):
 
     uuid = options["uuid"]
     label = options.get("label")
+    metadata_csum_seed = options.get("metadata_csum_seed")
+    orphan_file = options.get("orphan_file")
     verity = options.get("verity")
     opts = []
 
     if label:
         opts = ["-L", label]
+
+    if metadata_csum_seed is not None:
+        if metadata_csum_seed:
+            opts += ["-O", "metadata_csum_seed"]
+        else:
+            opts += ["-O", "^metadata_csum_seed"]
+
+    if orphan_file is not None:
+        if orphan_file:
+            opts += ["-O", "orphan_file"]
+        else:
+            opts += ["-O", "^orphan_file"]
 
     if verity is not None:
         if verity:


### PR DESCRIPTION
Add optional flags to the org.osbuild.mkfs.ext4 stage enabling/disabling the `metadata_csum_seed` and `orphan_file` features.