### PR TITLE
stages/org.osbuild.ostree.config: support bls-append-except-default

### DIFF
--- a/stages/org.osbuild.ostree.config
+++ b/stages/org.osbuild.ostree.config
@@ -42,6 +42,10 @@ SCHEMA = """
           "readonly": {
             "description": "Read only sysroot and boot",
             "type": "boolean"
+          },
+          "bls-append-except-default": {
+            "description": "Set value for bls-append-except-default",
+            "type": "string"
           }
         }
       }
@@ -63,6 +67,10 @@ def main(tree, options):
     if readonly is not None:  # can be False, which we would want to set
         ro = "true" if readonly else "false"
         ostree.cli("config", "set", "sysroot.readonly", ro, repo=repo)
+    
+    bls_append_except_default = sysroot_options.get("bls-append-except-default")
+    if bls_append_except_default:
+        ostree.cli("config", "set", "sysroot.bls-append-except-default", bls_append_except_default, repo=repo)
 
 
 if __name__ == '__main__':

--- a/test/data/manifests/fedora-coreos-container.json
+++ b/test/data/manifests/fedora-coreos-container.json
@@ -466,7 +466,8 @@
             "config": {
               "sysroot": {
                 "readonly": false,
-                "bootloader": "none"
+                "bootloader": "none",
+                "bls-append-except-default": "grub_users=\"\""
               }
             }
           }

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -89,6 +89,7 @@ pipelines:
             sysroot:
               readonly: false
               bootloader: none
+              bls-append-except-default: grub_users=""
       - type: org.osbuild.mkdir
         options:
           paths:


### PR DESCRIPTION
Create an optional parameter to enable bls-append-except-default needed to support GRUB password. This change allows the `ext.config.butane.grub-users` test for CoreOS to pass.

Test Output:
```
$ kola run -E /home/luyang/dev/fedora-coreos-config 'ext.fedora-coreos-config.butane.grub-users' --qemu-image=/home/luyang/KVM_Share/extend-bls.qcow2
=== RUN   ext.fedora-coreos-config.butane.grub-users
--- PASS: ext.fedora-coreos-config.butane.grub-users (46.95s)
PASS, output in _kola_temp/qemu-2024-01-10-1235-277335
```