### PR TITLE
osbuild/util/ostree: add default-deployment option

### DIFF
--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -30,7 +30,11 @@ SCHEMA_2 = """
   "type": { "type": "string" },
   "options": {
     "type": "object",
-    "required": ["deployment"],
+    "oneOf": [{
+      "required": ["deployment"]
+    }, {
+      "required": ["default-deployment"]
+    }],
     "properties": {
       "deployment": {
         "type": "object",
@@ -51,6 +55,11 @@ SCHEMA_2 = """
             "default": 0
           }
         }
+      },
+      "default-deployment": {
+        "description": "Use the default ostree deployment",
+        "type": "boolean",
+        "default": false
       }
     }
   }
@@ -79,10 +88,12 @@ class OSTreeDeploymentMount(mounts.MountService):
         tree = args["tree"]
         options = args["options"]
 
-        deployment = options["deployment"]
-        osname = deployment["osname"]
-        ref = deployment["ref"]
-        serial = deployment.get("serial", 0)
+        default_deployment = options.get("default-deployment", False)
+        if not default_deployment:
+          deployment = options["deployment"]
+          osname = deployment["osname"]
+          ref = deployment["ref"]
+          serial = deployment.get("serial", 0)
 
         # create a private mountpoint for the tree, which is needed
         # in order to be able to move the `root` mountpoint, which
@@ -91,11 +102,18 @@ class OSTreeDeploymentMount(mounts.MountService):
         #                                              - `mount(8)`
         self.tree = self.bind_mount(tree, tree)
 
-        root = ostree.deployment_path(tree, osname, ref, serial)
+        if default_deployment:
+            root = ostree.deployment_path(tree)
+        elif not default_deployment:
+            root = ostree.deployment_path(tree, osname, ref, serial)
 
         print(f"Deployment root at '{os.path.relpath(root, tree)}'")
 
-        var = os.path.join(tree, "ostree", "deploy", osname, "var")
+        if default_deployment:
+            stateroot = ostree.stateroot_path(tree)
+            var = os.path.join(stateroot, "var")
+        elif not default_deployment:
+            var = os.path.join(tree, "ostree", "deploy", osname, "var")
         boot = os.path.join(tree, "boot")
 
         self.mountpoint = root

--- a/mounts/org.osbuild.ostree.deployment
+++ b/mounts/org.osbuild.ostree.deployment
@@ -30,16 +30,31 @@ SCHEMA_2 = """
   "type": { "type": "string" },
   "options": {
     "type": "object",
-    "oneOf": [{
-      "required": ["deployment"]
-    }, {
-      "required": ["default-deployment"]
-    }],
+    "required": ["deployment"],
     "properties": {
       "deployment": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["osname", "ref"],
+        "oneOf": [
+          {
+            "properties": {
+              "default": {"enum": [false]}
+            },
+            "required": ["osname", "ref"]
+          },
+          {
+            "properties": {
+              "default": {"enum": [true]}
+            },
+            "not": { 
+              "anyOf": [
+                {"required": ["osname"]},
+                {"required": ["ref"]},
+                {"required": ["serial"]}
+              ]
+            }
+          }
+        ],
         "properties": {
           "osname": {
             "description": "Name of the stateroot to be used in the deployment",
@@ -53,13 +68,13 @@ SCHEMA_2 = """
             "description": "The deployment serial (usually '0')",
             "type": "number",
             "default": 0
+          },
+          "default": {
+            "description": "Find and use the default ostree deployment",
+            "type": "boolean",
+            "default": false
           }
         }
-      },
-      "default-deployment": {
-        "description": "Use the default ostree deployment",
-        "type": "boolean",
-        "default": false
       }
     }
   }
@@ -88,12 +103,8 @@ class OSTreeDeploymentMount(mounts.MountService):
         tree = args["tree"]
         options = args["options"]
 
-        default_deployment = options.get("default-deployment", False)
-        if not default_deployment:
-          deployment = options["deployment"]
-          osname = deployment["osname"]
-          ref = deployment["ref"]
-          serial = deployment.get("serial", 0)
+        deployment = options["deployment"]
+        osname, ref, serial = ostree.parse_deployment_option(tree, deployment)
 
         # create a private mountpoint for the tree, which is needed
         # in order to be able to move the `root` mountpoint, which
@@ -102,18 +113,11 @@ class OSTreeDeploymentMount(mounts.MountService):
         #                                              - `mount(8)`
         self.tree = self.bind_mount(tree, tree)
 
-        if default_deployment:
-            root = ostree.deployment_path(tree)
-        elif not default_deployment:
-            root = ostree.deployment_path(tree, osname, ref, serial)
+        root = ostree.deployment_path(tree, osname, ref, serial)
 
         print(f"Deployment root at '{os.path.relpath(root, tree)}'")
 
-        if default_deployment:
-            stateroot = ostree.stateroot_path(tree)
-            var = os.path.join(stateroot, "var")
-        elif not default_deployment:
-            var = os.path.join(tree, "ostree", "deploy", osname, "var")
+        var = os.path.join(tree, "ostree", "deploy", osname, "var")
         boot = os.path.join(tree, "boot")
 
         self.mountpoint = root

--- a/osbuild/util/ostree.py
+++ b/osbuild/util/ostree.py
@@ -215,6 +215,17 @@ def parse_input_commits(commits):
     return commits["path"], data["refs"]
 
 
+def stateroot_path(root: PathLike):
+    """Return the path to a deployment given the tree path"""
+
+    filenames = glob.glob(os.path.join(root, 'ostree/deploy/*'), recursive=True)
+    if len(filenames) < 1:
+        raise ValueError("Could not find stateroot")
+    if len(filenames) > 1:
+        raise ValueError("More than one stateroot found")
+    return filenames[0]
+
+
 def deployment_path(root: PathLike, osname: str = "", ref: str = "", serial: int = None):
     """Return the path to a deployment given the parameters"""
 

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -26,11 +26,29 @@ SCHEMA_2 = r"""
 },
 "options": {
 "additionalProperties": true,
-"not": { "required": ["deployment", "default-deployment"]},
 "properties": {
   "deployment": {
     "additionalProperties": false,
-    "required": ["osname", "ref"],
+    "oneOf": [
+      {
+        "properties": {
+          "default": {"enum": [false]}
+        },
+        "required": ["osname", "ref"]
+      },
+      {
+        "properties": {
+          "default": {"enum": [true]}
+        },
+        "not": { 
+          "anyOf": [
+            {"required": ["osname"]},
+            {"required": ["ref"]},
+            {"required": ["serial"]}
+          ]
+        }
+      }
+    ],
     "properties": {
       "osname": {
         "description": "Name of the stateroot to be used in the deployment",
@@ -44,13 +62,13 @@ SCHEMA_2 = r"""
         "description": "The deployment serial (usually '0')",
         "type": "number",
         "default": 0
+      },
+      "default": {
+        "description": "Find and use the default ostree deployment",
+        "type": "boolean",
+        "default": false
       }
     }
-  },
-  "default-deployment": {
-    "description": "Use the default ostree deployment",
-    "type": "boolean",
-    "default": false
   },
   "static-configs": {
     "description": "Install the grub configs defined for Fedora CoreOS",
@@ -75,13 +93,7 @@ def main(args, options):
     static_configs = options.get("static-configs", False)
     bios = options.get("bios", {})
     disk = bios.get("disk", "")
-
-    default_deployment = options.get("default-deployment", False)
-    if not default_deployment:    
-        dep = options["deployment"]
-        osname = dep["osname"]
-        ref = dep["ref"]
-        serial = dep.get("serial", 0)
+    deployment = options["deployment"]
 
     # Get the path where the filesystems are mounted
     mounts = args["paths"]["mounts"]
@@ -89,12 +101,11 @@ def main(args, options):
     # Get the deployment root. For non-OSTree this is simply
     # the root location of the mount points. For OSTree systems
     # we'll call ostree.deployment_path() helper to find it for us.
-    deployment = mounts
     if os.path.isdir(os.path.join(mounts, "ostree")):
-        if default_deployment:
-            deployment = ostree.deployment_path(mounts)
-        elif not default_deployment:
-            deployment = ostree.deployment_path(mounts, osname, ref, serial)
+        osname, ref, serial = ostree.parse_deployment_option(mounts, deployment)
+        deployment = ostree.deployment_path(mounts, osname, ref, serial)
+    else:
+        deployment = mounts
 
     bootupd_args = []
     if disk:

--- a/stages/org.osbuild.bootupd
+++ b/stages/org.osbuild.bootupd
@@ -26,7 +26,32 @@ SCHEMA_2 = r"""
 },
 "options": {
 "additionalProperties": true,
+"not": { "required": ["deployment", "default-deployment"]},
 "properties": {
+  "deployment": {
+    "additionalProperties": false,
+    "required": ["osname", "ref"],
+    "properties": {
+      "osname": {
+        "description": "Name of the stateroot to be used in the deployment",
+        "type": "string"
+      },
+      "ref": {
+        "description": "OStree ref to create and use for deployment",
+        "type": "string"
+      },
+      "serial": {
+        "description": "The deployment serial (usually '0')",
+        "type": "number",
+        "default": 0
+      }
+    }
+  },
+  "default-deployment": {
+    "description": "Use the default ostree deployment",
+    "type": "boolean",
+    "default": false
+  },
   "static-configs": {
     "description": "Install the grub configs defined for Fedora CoreOS",
     "type": "boolean"
@@ -51,6 +76,13 @@ def main(args, options):
     bios = options.get("bios", {})
     disk = bios.get("disk", "")
 
+    default_deployment = options.get("default-deployment", False)
+    if not default_deployment:    
+        dep = options["deployment"]
+        osname = dep["osname"]
+        ref = dep["ref"]
+        serial = dep.get("serial", 0)
+
     # Get the path where the filesystems are mounted
     mounts = args["paths"]["mounts"]
 
@@ -59,7 +91,10 @@ def main(args, options):
     # we'll call ostree.deployment_path() helper to find it for us.
     deployment = mounts
     if os.path.isdir(os.path.join(mounts, "ostree")):
-        deployment = ostree.deployment_path(mounts)
+        if default_deployment:
+            deployment = ostree.deployment_path(mounts)
+        elif not default_deployment:
+            deployment = ostree.deployment_path(mounts, osname, ref, serial)
 
     bootupd_args = []
     if disk:

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -24,7 +24,11 @@ SCHEMA = """
   "ostree": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["deployment"],
+    "oneOf": [{
+      "required": ["deployment"]
+    }, {
+      "required": ["default-deployment"]
+    }],
     "properties": {
       "deployment": {
         "type": "object",
@@ -45,6 +49,11 @@ SCHEMA = """
             "default": 0
           }
         }
+      },
+      "default-deployment": {
+        "description": "Use the default ostree deployment",
+        "type": "boolean",
+        "default": false
       }
     }
   },
@@ -113,6 +122,7 @@ SCHEMA = """
 def main(tree, options):
     filesystems = options["filesystems"]
     ostree_options = options.get("ostree")
+    default_deployment = options.get("default-deployment", False)
 
     path = f"{tree}/etc/fstab"
 
@@ -122,7 +132,10 @@ def main(tree, options):
         ref = deployment["ref"]
         serial = deployment.get("serial", 0)
 
-        root = ostree.deployment_path(tree, osname, ref, serial)
+        if default_deployment:
+            root = ostree.deployment_path(tree)
+        elif not default_deployment:
+            root = ostree.deployment_path(tree, osname, ref, serial)
 
         print(f"ostree support active: {root}")
 

--- a/stages/org.osbuild.fstab
+++ b/stages/org.osbuild.fstab
@@ -24,16 +24,31 @@ SCHEMA = """
   "ostree": {
     "type": "object",
     "additionalProperties": false,
-    "oneOf": [{
-      "required": ["deployment"]
-    }, {
-      "required": ["default-deployment"]
-    }],
+    "required": ["deployment"],
     "properties": {
       "deployment": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["osname","ref"],
+        "oneOf": [
+          {
+            "properties": {
+              "default": {"enum": [false]}
+            },
+            "required": ["osname", "ref"]
+          },
+          {
+            "properties": {
+              "default": {"enum": [true]}
+            },
+            "not": { 
+              "anyOf": [
+                {"required": ["osname"]},
+                {"required": ["ref"]},
+                {"required": ["serial"]}
+              ]
+            }
+          }
+        ],
         "properties": {
           "osname": {
             "description": "Name of the stateroot to be used in the deployment",
@@ -47,13 +62,13 @@ SCHEMA = """
             "description": "The deployment serial (usually '0')",
             "type": "number",
             "default": 0
+          },
+          "default": {
+            "description": "Find and use the default ostree deployment",
+            "type": "boolean",
+            "default": false
           }
         }
-      },
-      "default-deployment": {
-        "description": "Use the default ostree deployment",
-        "type": "boolean",
-        "default": false
       }
     }
   },
@@ -122,20 +137,14 @@ SCHEMA = """
 def main(tree, options):
     filesystems = options["filesystems"]
     ostree_options = options.get("ostree")
-    default_deployment = options.get("default-deployment", False)
 
     path = f"{tree}/etc/fstab"
 
     if ostree_options:
         deployment = ostree_options["deployment"]
-        osname = deployment["osname"]
-        ref = deployment["ref"]
-        serial = deployment.get("serial", 0)
+        osname, ref, serial = ostree.parse_deployment_option(tree, deployment)
 
-        if default_deployment:
-            root = ostree.deployment_path(tree)
-        elif not default_deployment:
-            root = ostree.deployment_path(tree, osname, ref, serial)
+        root = ostree.deployment_path(tree, osname, ref, serial)
 
         print(f"ostree support active: {root}")
 

--- a/stages/org.osbuild.ostree.aleph
+++ b/stages/org.osbuild.ostree.aleph
@@ -19,6 +19,11 @@ COREOS_ALEPH_FILENAME = ".coreos-aleph-version.json"
 SCHEMA_2 = """
 "options": {
   "additionalProperties": false,
+  "oneOf": [{
+    "required": ["deployment"]
+  }, {
+    "required": ["default-deployment"]
+  }],
   "properties": {
     "coreos_compat": {
       "description": "boolean to allow for CoreOS aleph version backwards compatibility",
@@ -42,6 +47,11 @@ SCHEMA_2 = """
           "default": 0
         }
       }
+    },
+    "default-deployment": {
+      "description": "Use the default ostree deployment",
+      "type": "boolean",
+      "default": false
     }
   }
 }
@@ -132,12 +142,18 @@ def construct_aleph_json(tree, origin):
 
 def main(tree, options):
     coreos_compat = options.get("coreos_compat", False)
-    dep = options["deployment"]
-    osname = dep["osname"]
-    ref = dep["ref"]
-    serial = dep.get("serial", 0)
 
-    origin = ostree.deployment_path(tree, osname, ref, serial) + ".origin"
+    default_deployment = options.get("default-deployment", False)
+    if not default_deployment:
+      dep = options["deployment"]
+      osname = dep["osname"]
+      ref = dep["ref"]
+      serial = dep.get("serial", 0)
+
+    if default_deployment:
+        origin = ostree.deployment_path(tree) + ".origin"
+    elif not default_deployment:
+        origin = ostree.deployment_path(tree, osname, ref, serial) + ".origin"
     data = construct_aleph_json(tree, origin)
 
     # write the data out to the file

--- a/stages/org.osbuild.ostree.aleph
+++ b/stages/org.osbuild.ostree.aleph
@@ -19,11 +19,7 @@ COREOS_ALEPH_FILENAME = ".coreos-aleph-version.json"
 SCHEMA_2 = """
 "options": {
   "additionalProperties": false,
-  "oneOf": [{
-    "required": ["deployment"]
-  }, {
-    "required": ["default-deployment"]
-  }],
+  "required": ["deployment"],
   "properties": {
     "coreos_compat": {
       "description": "boolean to allow for CoreOS aleph version backwards compatibility",
@@ -31,7 +27,26 @@ SCHEMA_2 = """
     },
     "deployment": {
       "additionalProperties": false,
-      "required": ["osname", "ref"],
+      "oneOf": [
+        {
+          "properties": {
+            "default": {"enum": [false]}
+          },
+          "required": ["osname", "ref"]
+        },
+        {
+          "properties": {
+            "default": {"enum": [true]}
+          },
+          "not": { 
+            "anyOf": [
+              {"required": ["osname"]},
+              {"required": ["ref"]},
+              {"required": ["serial"]}
+            ]
+          }
+        }
+      ],
       "properties": {
         "osname": {
           "description": "Name of the stateroot to be used in the deployment",
@@ -45,13 +60,13 @@ SCHEMA_2 = """
           "description": "The deployment serial (usually '0')",
           "type": "number",
           "default": 0
+        },
+        "default": {
+          "description": "Find and use the default ostree deployment",
+          "type": "boolean",
+          "default": false
         }
       }
-    },
-    "default-deployment": {
-      "description": "Use the default ostree deployment",
-      "type": "boolean",
-      "default": false
     }
   }
 }
@@ -142,18 +157,10 @@ def construct_aleph_json(tree, origin):
 
 def main(tree, options):
     coreos_compat = options.get("coreos_compat", False)
+    dep = options["deployment"]
+    osname, ref, serial = ostree.parse_deployment_option(tree, dep)
 
-    default_deployment = options.get("default-deployment", False)
-    if not default_deployment:
-      dep = options["deployment"]
-      osname = dep["osname"]
-      ref = dep["ref"]
-      serial = dep.get("serial", 0)
-
-    if default_deployment:
-        origin = ostree.deployment_path(tree) + ".origin"
-    elif not default_deployment:
-        origin = ostree.deployment_path(tree, osname, ref, serial) + ".origin"
+    origin = ostree.deployment_path(tree, osname, ref, serial) + ".origin"
     data = construct_aleph_json(tree, origin)
 
     # write the data out to the file

--- a/stages/org.osbuild.ostree.fillvar
+++ b/stages/org.osbuild.ostree.fillvar
@@ -14,15 +14,30 @@ from osbuild.util.mnt import MountGuard
 
 SCHEMA = """
 "additionalProperties": false,
-"oneOf": [{
-  "required": ["deployment"]
-}, {
-  "required": ["default-deployment"]
-}],
+"required": ["deployment"],
 "properties": {
   "deployment": {
     "additionalProperties": false,
-    "required": ["osname", "ref"],
+    "oneOf": [
+      {
+        "properties": {
+          "default": {"enum": [false]}
+        },
+        "required": ["osname", "ref"]
+      },
+      {
+        "properties": {
+          "default": {"enum": [true]}
+        },
+        "not": { 
+          "anyOf": [
+            {"required": ["osname"]},
+            {"required": ["ref"]},
+            {"required": ["serial"]}
+          ]
+        }
+      }
+    ],
     "properties": {
       "osname": {
         "description": "Name of the stateroot to be used in the deployment",
@@ -36,13 +51,13 @@ SCHEMA = """
         "description": "The deployment serial (usually '0')",
         "type": "number",
         "default": 0
+      },
+      "default": {
+        "description": "Find and use the default ostree deployment",
+        "type": "boolean",
+        "default": false
       }
     }
-  },
-  "default-deployment": {
-    "description": "Use the default ostree deployment",
-    "type": "boolean",
-    "default": false
   }
 }
 """
@@ -79,20 +94,11 @@ def populate_var(sysroot):
 
 
 def main(tree, options):
-    default_deployment = options.get("default-deployment", False)
-    if not default_deployment:
-      dep = options["deployment"]
-      osname = dep["osname"]
-      ref = dep["ref"]
-      serial = dep.get("serial", 0)
+    dep = options["deployment"]
+    osname, ref, serial = ostree.parse_deployment_option(tree, dep)
 
-    if default_deployment:
-        deployment = ostree.deployment_path(tree)
-        stateroot = ostree.stateroot_path(tree)
-        var = os.path.join(stateroot, "var")
-    elif not default_deployment:
-        deployment = ostree.deployment_path(tree, osname, ref, serial)
-        var = os.path.join(tree, "ostree", "deploy", osname, "var")
+    deployment = ostree.deployment_path(tree, osname, ref, serial)
+    var = os.path.join(tree, "ostree", "deploy", osname, "var")
 
     with MountGuard() as mgr:
         mgr.mount(var, f"{deployment}/var")

--- a/stages/org.osbuild.ostree.fillvar
+++ b/stages/org.osbuild.ostree.fillvar
@@ -14,7 +14,11 @@ from osbuild.util.mnt import MountGuard
 
 SCHEMA = """
 "additionalProperties": false,
-"required": ["deployment"],
+"oneOf": [{
+  "required": ["deployment"]
+}, {
+  "required": ["default-deployment"]
+}],
 "properties": {
   "deployment": {
     "additionalProperties": false,
@@ -34,6 +38,11 @@ SCHEMA = """
         "default": 0
       }
     }
+  },
+  "default-deployment": {
+    "description": "Use the default ostree deployment",
+    "type": "boolean",
+    "default": false
   }
 }
 """
@@ -70,13 +79,20 @@ def populate_var(sysroot):
 
 
 def main(tree, options):
-    dep = options["deployment"]
-    osname = dep["osname"]
-    ref = dep["ref"]
-    serial = dep.get("serial", 0)
+    default_deployment = options.get("default-deployment", False)
+    if not default_deployment:
+      dep = options["deployment"]
+      osname = dep["osname"]
+      ref = dep["ref"]
+      serial = dep.get("serial", 0)
 
-    deployment = ostree.deployment_path(tree, osname, ref, serial)
-    var = os.path.join(tree, "ostree", "deploy", osname, "var")
+    if default_deployment:
+        deployment = ostree.deployment_path(tree)
+        stateroot = ostree.stateroot_path(tree)
+        var = os.path.join(stateroot, "var")
+    elif not default_deployment:
+        deployment = ostree.deployment_path(tree, osname, ref, serial)
+        var = os.path.join(tree, "ostree", "deploy", osname, "var")
 
     with MountGuard() as mgr:
         mgr.mount(var, f"{deployment}/var")

--- a/stages/org.osbuild.ostree.selinux
+++ b/stages/org.osbuild.ostree.selinux
@@ -17,7 +17,11 @@ CAPABILITIES = ["CAP_MAC_ADMIN"]
 
 SCHEMA = """
 "additionalProperties": false,
-"required": ["deployment"],
+"oneOf": [{
+  "required": ["deployment"]
+}, {
+  "required": ["default-deployment"]
+}],
 "properties": {
   "deployment": {
     "additionalProperties": false,
@@ -37,21 +41,32 @@ SCHEMA = """
         "default": 0
       }
     }
+  },
+  "default-deployment": {
+    "description": "Use the default ostree deployment",
+    "type": "boolean",
+    "default": false
   }
 }
 """
 
 
 def main(tree, options):
-    dep = options["deployment"]
-    osname = dep["osname"]
-    ref = dep["ref"]
-    serial = dep.get("serial", 0)
+    default_deployment = options.get("default-deployment", False)
+    if not default_deployment:
+      dep = options["deployment"]
+      osname = dep["osname"]
+      ref = dep["ref"]
+      serial = dep.get("serial", 0)
 
-    # this created a state root at `osname`
-    stateroot = f"{tree}/ostree/deploy/{osname}"
-
-    root = ostree.deployment_path(tree, osname, ref, serial)
+    if default_deployment:
+        # this automatically finds the state root
+        stateroot = ostree.stateroot_path(tree)
+        root = ostree.deployment_path(tree)
+    elif not default_deployment:
+        # this created a state root at `osname`
+        stateroot = f"{tree}/ostree/deploy/{osname}"
+        root = ostree.deployment_path(tree, osname, ref, serial)
 
     # deploying a tree creates new files that need to be properly
     # labeled for SELinux. In theory, ostree will take care of

--- a/stages/org.osbuild.ostree.selinux
+++ b/stages/org.osbuild.ostree.selinux
@@ -17,15 +17,30 @@ CAPABILITIES = ["CAP_MAC_ADMIN"]
 
 SCHEMA = """
 "additionalProperties": false,
-"oneOf": [{
-  "required": ["deployment"]
-}, {
-  "required": ["default-deployment"]
-}],
+"required": ["deployment"],
 "properties": {
   "deployment": {
     "additionalProperties": false,
-    "required": ["osname", "ref"],
+    "oneOf": [
+      {
+        "properties": {
+          "default": {"enum": [false]}
+        },
+        "required": ["osname", "ref"]
+      },
+      {
+        "properties": {
+          "default": {"enum": [true]}
+        },
+        "not": { 
+          "anyOf": [
+            {"required": ["osname"]},
+            {"required": ["ref"]},
+            {"required": ["serial"]}
+          ]
+        }
+      }
+    ],
     "properties": {
       "osname": {
         "description": "Name of the stateroot to be used in the deployment",
@@ -39,34 +54,26 @@ SCHEMA = """
         "description": "The deployment serial (usually '0')",
         "type": "number",
         "default": 0
+      },
+      "default": {
+        "description": "Find and use the default ostree deployment",
+        "type": "boolean",
+        "default": false
       }
     }
-  },
-  "default-deployment": {
-    "description": "Use the default ostree deployment",
-    "type": "boolean",
-    "default": false
   }
 }
 """
 
 
 def main(tree, options):
-    default_deployment = options.get("default-deployment", False)
-    if not default_deployment:
-      dep = options["deployment"]
-      osname = dep["osname"]
-      ref = dep["ref"]
-      serial = dep.get("serial", 0)
+    dep = options["deployment"]
+    osname, ref, serial = ostree.parse_deployment_option(tree, dep)
 
-    if default_deployment:
-        # this automatically finds the state root
-        stateroot = ostree.stateroot_path(tree)
-        root = ostree.deployment_path(tree)
-    elif not default_deployment:
-        # this created a state root at `osname`
-        stateroot = f"{tree}/ostree/deploy/{osname}"
-        root = ostree.deployment_path(tree, osname, ref, serial)
+    # this created a state root at `osname`
+    stateroot = f"{tree}/ostree/deploy/{osname}"
+
+    root = ostree.deployment_path(tree, osname, ref, serial)
 
     # deploying a tree creates new files that need to be properly
     # labeled for SELinux. In theory, ostree will take care of

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -116,14 +116,10 @@ pipelines:
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true
-          deployment:
-            osname: fedora-coreos
-            ref: ostree/1/1/0
+          default-deployment: true
       - type: org.osbuild.ostree.selinux
         options:
-          deployment:
-            osname: fedora-coreos
-            ref: ostree/1/1/0
+          default-deployment: true
   - name: raw-image
     build: name:build
     stages:
@@ -223,6 +219,7 @@ pipelines:
           bios:
             disk: disk
           static-configs: true
+          default-deployment: true
         devices:
           disk:
             type: org.osbuild.loopback

--- a/test/data/manifests/fedora-coreos-container.mpp.yaml
+++ b/test/data/manifests/fedora-coreos-container.mpp.yaml
@@ -116,10 +116,12 @@ pipelines:
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true
-          default-deployment: true
+          deployment:
+            default: true
       - type: org.osbuild.ostree.selinux
         options:
-          default-deployment: true
+          deployment:
+            default: true
   - name: raw-image
     build: name:build
     stages:
@@ -219,7 +221,8 @@ pipelines:
           bios:
             disk: disk
           static-configs: true
-          default-deployment: true
+          deployment:
+            default: true
         devices:
           disk:
             type: org.osbuild.loopback


### PR DESCRIPTION
Modify stages that take in an explicit deployment option to also
allow a default-deployment option. The schemas for these stages
has also been modifed to only accept one of the two.

Create a function that automatically detects the stateroot path 
at `{tree}/ostree/deploy/{osname}`. Used to find the path
for the `var` directory when using the default deployment option
instead of explicitly specifying the deployment.